### PR TITLE
a potential bug in filter_self_loops function

### DIFF
--- a/d3-ForceEdgeBundling.js
+++ b/d3-ForceEdgeBundling.js
@@ -99,7 +99,7 @@ Author: Corneliu S. (github.com/upphiminn)
 		function filter_self_loops(edgelist){
 			var filtered_edge_list = [];
 			for(var e=0; e < edgelist.length; e++){
-				if(data_nodes[edgelist[e].source].x != data_nodes[edgelist[e].target].x  &&
+				if(data_nodes[edgelist[e].source].x != data_nodes[edgelist[e].target].x  ||
 				   data_nodes[edgelist[e].source].y != data_nodes[edgelist[e].target].y ){ //or smaller than eps
 					filtered_edge_list.push(edgelist[e]);
 


### PR DESCRIPTION
Hi, upphiminn,
I just found a potential bug when applying the library on my dataset.
in the function of *filter_self_loops(edgelist)*, if *and* operation is used, I think  absolute horizontal or vertical edges will be discarded and won't be added to the *filtered_edge_list*.
Thus, I think *or* operation may be more proper here.
Thanks for your attention on my suggestion.

Best,
Guodao